### PR TITLE
build: remove sphinx version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def main():
                           'tables'],
         extras_require={
             'test': ['pytest', 'nbval', 'django', 'nbformat'],
-            'docs': ['sphinx<8', 'sphinx-rtd-theme', 'mock', 'nbsphinx',
+            'docs': ['sphinx', 'sphinx-rtd-theme', 'mock', 'nbsphinx',
                      'ipykernel'],
         },
         cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
Required version of sphinx is already pinned by sphinx-rtd-theme. They should update their version range when they add sphinx v8 support.