### PR TITLE
fix(docs): render plotly figures correctly in readthedocs tutorial

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,10 +16,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import mock
 import os
 import sys
 from packaging.version import Version
+from unittest import mock
 import datetime
 
 sys.path.insert(0, os.path.abspath('../'))

--- a/doc/tutorial.ipynb
+++ b/doc/tutorial.ipynb
@@ -32,25 +32,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Start Jupyter Notebook"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Run jupyter notebook with the following argument:\n",
-    "\n",
-    "    jupyter notebook --NotebookApp.iopub_data_rate_limit=1.0e10\n",
-    "    \n",
-    "The data rate limit needs to be increased or `init_notebook_mode()` throws an error.\n",
-    "This is a [plotly requirement](https://community.plot.ly/t/tips-for-using-plotly-with-jupyter-notebook-5-0-the-latest-version/4156)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Load a file"
    ]
   },
@@ -150,7 +131,7 @@
    "source": [
     "## Setting up plots\n",
     "\n",
-    "Each of the `plot_X` functions returns a plotly `Figure` object which can be visualised in a number of ways. Here, we use the offline `iplot` function, which generates a plot for use with Jupyter notebook. We could also generate plots using the `plot` function in standalone HTML files. See the [plotly documentation](https://plot.ly/python/offline/) for more information on the latter approach. "
+    "Each of the `plot_X` functions returns a plotly `Figure` object. When displayed in a notebook or on this documentation page, plots are rendered interactively. To save a plot as a standalone HTML file, use `plotly.io.write_html`; see the [plotly documentation](https://plotly.com/python/interactive-html-export/) for details."
    ]
   },
   {
@@ -166,6 +147,19 @@
     "    plot_ctrl_dip_by_plate,\n",
     "    plot_plate_map,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.io as pio\n",
+    "\n",
+    "# Use the notebook_connected renderer so plots display correctly in\n",
+    "# both Jupyter and on the documentation pages (nbsphinx).\n",
+    "pio.renderers.default = 'notebook_connected'"
    ]
   },
   {


### PR DESCRIPTION
Set plotly renderer to notebook_connected so figures are output as text/html (with a CDN plotly.js link) rather than the application/vnd.plotly.v1+json MIME type that nbsphinx cannot display.

Also removes the outdated 'Start Jupyter Notebook' section (referenced the long-removed iplot/init_notebook_mode API) and updates the 'Setting up plots' prose to reflect the current plotly API.