### PR TITLE
chore(deps): remove stale optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ It makes extensive use of [pandas](http://pandas.pydata.org/) and
 
 ## Installation
 
-Thunor Core is tested against the three most recent stable releases
-of Python (currently 3.10-3.12), so one of these versions is
-recommended. Install Thunor Core using `pip`:
+Thunor Core's Python version support aims to match that of pandas,
+which is currently 3.11-3.14.
+
+Install Thunor Core using `pip`:
 
 ```
 pip install thunor
@@ -36,8 +37,6 @@ repository and change into the `thunor` directory.
 To build documentation locally, you'll need a few software dependencies:
 
     pip install -e '.[docs]'
-
-You'll also need to install [pandoc](https://pandoc.org/installing.html).
 
 Then, you can build the documentation like so:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,8 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ['pytest', 'nbval', 'django', 'nbformat', 'ruff',
-        'codecov', 'pytest-cov']
-docs = ['sphinx', 'sphinx-rtd-theme', 'mock', 'nbsphinx',
-        'ipykernel']
+test = ['pytest', 'nbval', 'ruff', 'pytest-cov']
+docs = ['sphinx', 'sphinx-rtd-theme', 'nbsphinx', 'ipykernel']
 
 [project.urls]
 Homepage = "https://www.thunor.net"

--- a/thunor/helpers.py
+++ b/thunor/helpers.py
@@ -1,14 +1,30 @@
 # -*- coding: utf-8 -*-
 import collections
 from collections.abc import Iterable
+from html.parser import HTMLParser
 import pandas as pd
 from pandas.core.indexes.base import InvalidIndexError
 from functools import reduce
 
-try:
-    from django.utils.html import strip_tags
-except ImportError:
-    strip_tags = None
+
+class _TagStripper(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._parts = []
+
+    def handle_data(self, data):
+        self._parts.append(data)
+
+    def get_data(self):
+        return ''.join(self._parts)
+
+
+def _strip_tags(text):
+    if text is None:
+        return ''
+    s = _TagStripper()
+    s.feed(text)
+    return s.get_data()
 
 
 _SI_PREFIXES = collections.OrderedDict(
@@ -65,20 +81,17 @@ def format_dose(num, sig_digits=12, array_as_string=None):
 
 
 def _plotly_scatter_to_dataframe(plot_fig):
-    if strip_tags is None:
-        raise ImportError('This function requires django')
-
     rows = []
     try:
-        xaxis_name = strip_tags(plot_fig['layout']['xaxis']['title']['text'])
+        xaxis_name = _strip_tags(plot_fig['layout']['xaxis']['title']['text'])
     except KeyError:
         xaxis_name = 'x'
     try:
-        yaxis_name = strip_tags(plot_fig['layout']['yaxis']['title']['text'])
+        yaxis_name = _strip_tags(plot_fig['layout']['yaxis']['title']['text'])
     except KeyError:
         yaxis_name = 'y'
     for trace in plot_fig['data']:
-        trace_name = strip_tags(trace['name'])
+        trace_name = _strip_tags(trace['name'])
         if trace['x'] is None:
             continue
         for i in range(len(trace['x'])):
@@ -87,7 +100,7 @@ def _plotly_scatter_to_dataframe(plot_fig):
                     'trace_name': trace_name,
                     xaxis_name: trace['x'][i],
                     yaxis_name: trace['y'][i],
-                    'point_label': strip_tags(
+                    'point_label': _strip_tags(
                         trace['hovertext'][i].replace('<br>', '\n')
                     )
                     if trace['hovertext'] is not None

--- a/thunor/tests/test_helpers.py
+++ b/thunor/tests/test_helpers.py
@@ -1,0 +1,19 @@
+import pytest
+from thunor.helpers import _strip_tags
+
+
+@pytest.mark.parametrize(
+    'text, expected',
+    [
+        ('plain text', 'plain text'),
+        ('<b>bold</b>', 'bold'),
+        ('<span style="color:red">text</span>', 'text'),
+        ('before<br>after', 'beforeafter'),
+        ('a &amp; b', 'a & b'),
+        ('<b>one</b> and <i>two</i>', 'one and two'),
+        ('', ''),
+        (None, ''),
+    ],
+)
+def test_strip_tags(text, expected):
+    assert _strip_tags(text) == expected


### PR DESCRIPTION
Drop mock (stdlib unittest.mock used since Python 3), codecov (replaced by the codecov GitHub Action), nbformat (indirect dep via nbval only), and django (replaced with stdlib html.parser for strip_tags).

Also removes the outdated pandoc requirement from README.md, which nbsphinx no longer needs since ~0.8.x.