### PR TITLE
fix(io): split concatenated column name in NA validation set

### DIFF
--- a/thunor/io.py
+++ b/thunor/io.py
@@ -623,7 +623,8 @@ def read_vanderbilt_hts(
             'time',
             'cell.count',
             'drug1.conc',
-            'drug1.unitsdrug2.conc',
+            'drug1.units',
+            'drug2.conc',
             'drug2.units',
         }
     )


### PR DESCRIPTION
Fixes a typo where `'drug1.unitsdrug2.conc'` was a single entry in the NA validation set, meaning neither `drug1.units` nor `drug2.conc` were checked for blank values.