### PR TITLE
fix(curve_fit): use _popt_rel backing field in popt_rel property

### DIFF
--- a/thunor/curve_fit.py
+++ b/thunor/curve_fit.py
@@ -402,8 +402,8 @@ class HillCurveLL4(HillCurve):
     def popt_rel(self):
         if self._popt_rel is None:
             self._popt_rel = self.popt.copy()
-            self.popt_rel[2] /= self.divisor
-            self.popt_rel[1] /= self.divisor
+            self._popt_rel[2] /= self.divisor
+            self._popt_rel[1] /= self.divisor
         return self._popt_rel
 
     def fit_rel(self, x):


### PR DESCRIPTION
Use `self._popt_rel[1]` and `self._popt_rel[2]` instead of calling the property recursively via `self.popt_rel`. Consistent with `HillCurveLL3u` which already does this correctly.