### PR TITLE
refactor(api): make plate_width/height and time_hrs keyword-only

### DIFF
--- a/thunor/io.py
+++ b/thunor/io.py
@@ -577,7 +577,7 @@ def _select_csv_separator(file_or_buf):
 
 
 def read_vanderbilt_hts(
-    file_or_source, plate_width=24, plate_height=16, sep=None, _unstacked=False
+    file_or_source, *, plate_width=24, plate_height=16, sep=None, _unstacked=False
 ):
     """
     Read a Vanderbilt HTS format file

--- a/thunor/viability.py
+++ b/thunor/viability.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 SECONDS_IN_HOUR = 3600
 
 
-def viability(df_data, time_hrs=72, assay_name=None, include_controls=True):
+def viability(df_data, *, time_hrs=72, assay_name=None, include_controls=True):
     """
     Calculate viability at the specified time point
 


### PR DESCRIPTION
Prevents silent breakage from positional argument order changes in future API updates. All existing call sites already pass these as keyword arguments.