### PR TITLE
perf(io): filter DataFrames before copying in HtsPandas.filter()

### DIFF
--- a/thunor/io.py
+++ b/thunor/io.py
@@ -305,8 +305,8 @@ class HtsPandas(object):
         if drugs is not None:
             drugs = [(drug,) if isinstance(drug, str) else drug for drug in drugs]
 
-        doses = self.doses.copy()
-        controls = self.controls.copy() if self.controls is not None else None
+        doses = self.doses
+        controls = self.controls
         if plate is not None:
             if isinstance(plate, str):
                 plate = [
@@ -314,7 +314,7 @@ class HtsPandas(object):
                 ]
 
             if 'plate' in doses.columns:
-                doses.set_index('plate', append=True, inplace=True)
+                doses = doses.set_index('plate', append=True)
 
             doses = doses[doses.index.isin(plate, level='plate')]
             if controls is not None:
@@ -330,14 +330,15 @@ class HtsPandas(object):
         if drugs is not None:
             doses = doses.iloc[doses.index.isin(drugs, level='drug'), :]
 
+        doses = doses.copy()
         doses.index = doses.index.remove_unused_levels()
         if controls is not None:
+            controls = controls.copy()
             controls.index = controls.index.remove_unused_levels()
 
-        assays = self.assays.copy()
-        assays = assays.iloc[
-            assays.index.isin(doses['well_id'].unique(), level='well_id'), :
-        ]
+        assays = self.assays.iloc[
+            self.assays.index.isin(doses['well_id'].unique(), level='well_id'), :
+        ].copy()
 
         return self.__class__(doses, assays, controls)
 


### PR DESCRIPTION
Previously `filter()` copied the full `doses`, `controls`, and `assays` DataFrames before discarding unwanted rows. Now filtering happens on references to the originals and only the reduced result is copied.