### PR TITLE
refactor: replace private attrs with DataFrame.attrs; consolidate SECONDS_IN_HOUR

### DIFF
--- a/thunor/curve_fit.py
+++ b/thunor/curve_fit.py
@@ -1189,10 +1189,9 @@ def fit_params_minimal(
     df_params = pd.DataFrame(fit_params)
     df_params.set_index(['dataset_id', 'cell_line', 'drug'], inplace=True)
 
-    df_params._drmetric = 'viability' if is_viability else 'dip'
+    df_params.attrs['drmetric'] = 'viability' if is_viability else 'dip'
     if is_viability:
-        df_params._viability_time = expt_data_orig._viability_time
-        df_params._viability_assay = expt_data_orig._viability_assay
+        df_params.attrs.update(expt_data_orig.attrs)
 
     return df_params
 
@@ -1261,7 +1260,7 @@ def _attach_extra_params(
 
     base_params['label'] = base_params.index.map(_generate_label)
 
-    is_viability = base_params._drmetric == 'viability'
+    is_viability = base_params.attrs.get('drmetric') == 'viability'
 
     # Determine which per-row columns are needed
     need_ec50 = 50 in custom_ec_concentrations
@@ -1379,7 +1378,7 @@ def _attach_extra_params(
 
 
 def _attach_response_values(df_params, ctrl_dip_data, expt_dip_data, ctrl_dose_fn):
-    is_viability = df_params._drmetric == 'viability'
+    is_viability = df_params.attrs.get('drmetric') == 'viability'
     data_list = []
     if 'dataset' not in expt_dip_data.index.names:
         expt_dip_data = expt_dip_data.copy()
@@ -1432,10 +1431,7 @@ def _attach_response_values(df_params, ctrl_dip_data, expt_dip_data, ctrl_dose_f
     df_params_old = df_params
     df_params = pd.concat([df, df_params], axis=1)
 
-    df_params._drmetric = df_params_old._drmetric
-    if is_viability:
-        df_params._viability_time = df_params_old._viability_time
-        df_params._viability_assay = df_params_old._viability_assay
+    df_params.attrs.update(df_params_old.attrs)
 
     return df_params
 

--- a/thunor/io.py
+++ b/thunor/io.py
@@ -7,9 +7,8 @@ import itertools
 import io
 import pathlib
 import re
-from .dip import _choose_dip_assay, dip_rates
+from .dip import SECONDS_IN_HOUR, _choose_dip_assay, dip_rates
 
-SECONDS_IN_HOUR = 3600
 ZERO_TIMEDELTA = timedelta(0)
 ASCII_A = 65
 ALPHABET_LENGTH = 26

--- a/thunor/plots.py
+++ b/thunor/plots.py
@@ -5,7 +5,7 @@ import numpy as np
 import seaborn as sns
 from . import config
 from .helpers import format_dose
-from .dip import ctrl_dip_rates, expt_dip_rates
+from .dip import SECONDS_IN_HOUR, ctrl_dip_rates, expt_dip_rates
 from .curve_fit import HillCurveNull, is_param_truncated
 import scipy.stats
 import re
@@ -31,7 +31,6 @@ def _auc_units(**kwargs):
         return ''
 
 
-SECONDS_IN_HOUR = 3600.0
 NS_IN_SEC = 1e9
 PLATE_MAP_WELL_DIAM = 0.95
 ASCII_CAP_A = 65
@@ -242,12 +241,10 @@ def plot_drc(
     # Shapes used for replicate markers
     shapes = ['circle', 'circle-open']
 
-    try:
-        is_viability = (
-            'viability' in fit_params.columns or fit_params._drmetric == 'viability'
-        )
-    except AttributeError:
-        is_viability = False
+    is_viability = (
+        'viability' in fit_params.columns
+        or fit_params.attrs.get('drmetric') == 'viability'
+    )
 
     if is_viability:
         # Only "absolute" (non-transformed y-axis) makes sense for viability
@@ -255,7 +252,7 @@ def plot_drc(
 
     if is_viability:
         yaxis_title = '{:g} hr viability'.format(
-            fit_params._viability_time.total_seconds() / SECONDS_IN_HOUR
+            fit_params.attrs['viability_time'].total_seconds() / SECONDS_IN_HOUR
         )
     else:
         yaxis_title = 'DIP rate'
@@ -700,11 +697,11 @@ def plot_two_dataset_param_scatter(
         subtitle = ' &amp; '.join(str(d) for d in datasets)
     title = _combine_title_subtitle(title, subtitle)
 
-    if df_params._drmetric == 'dip':
+    if df_params.attrs.get('drmetric') == 'dip':
         dr_metric = 'DIP'
     else:
         dr_metric = '{:g} hr viability'.format(
-            df_params._viability_time.total_seconds() / SECONDS_IN_HOUR
+            df_params.attrs['viability_time'].total_seconds() / SECONDS_IN_HOUR
         )
 
     df_params = df_params.loc[:, [fit_param, 'max_dose_measured', 'min_dose_measured']]
@@ -1015,11 +1012,12 @@ def plot_drc_params(
         yaxis_title = '{} ({})'.format(yaxis_param_name, yaxis_units)
     else:
         yaxis_title = yaxis_param_name
-    if df_params._drmetric in ('dip', 'compare'):
+    if df_params.attrs.get('drmetric') in ('dip', 'compare'):
         yaxis_title = 'DIP {}'.format(yaxis_title)
     else:
         yaxis_title = '{:g} hr viability {}'.format(
-            df_params._viability_time.total_seconds() / SECONDS_IN_HOUR, yaxis_title
+            df_params.attrs['viability_time'].total_seconds() / SECONDS_IN_HOUR,
+            yaxis_title,
         )
 
     layout = dict(
@@ -1057,11 +1055,12 @@ def plot_drc_params(
             xaxis_title = '{} ({})'.format(xaxis_param_name, xaxis_units)
         else:
             xaxis_title = xaxis_param_name
-        if df_params._drmetric == 'dip':
+        if df_params.attrs.get('drmetric') == 'dip':
             xaxis_title = 'DIP {}'.format(xaxis_title)
         else:
             xaxis_title = '{:g} hr viability {}'.format(
-                df_params._viability_time.total_seconds() / SECONDS_IN_HOUR, xaxis_title
+                df_params.attrs['viability_time'].total_seconds() / SECONDS_IN_HOUR,
+                xaxis_title,
             )
 
         range_bounded_params = set()

--- a/thunor/tests/test_plots.py
+++ b/thunor/tests/test_plots.py
@@ -58,7 +58,7 @@ class TestWithDataset(unittest.TestCase):
 
         df = pd.concat([df1, df2])
 
-        df._drmetric = self.fit_params._drmetric
+        df.attrs.update(self.fit_params.attrs)
 
         plot_drc_params(df, fit_param='ec50', multi_dataset=True)
 

--- a/thunor/viability.py
+++ b/thunor/viability.py
@@ -1,7 +1,5 @@
 from datetime import timedelta
 
-SECONDS_IN_HOUR = 3600
-
 
 def viability(df_data, time_hrs=72, assay_name=None, include_controls=True):
     """
@@ -98,8 +96,8 @@ def viability(df_data, time_hrs=72, assay_name=None, include_controls=True):
     if len(timepoints) == 1:
         time = timepoints[0]
 
-    df._viability_time = time
-    df._viability_assay = assay_name
+    df.attrs['viability_time'] = time
+    df.attrs['viability_assay'] = assay_name
 
     if include_controls:
         return df, controls['value']


### PR DESCRIPTION
\`_viability_time\`, \`_viability_assay\`, and \`_drmetric\` were monkey-patched onto DataFrames as private attributes, which is fragile and undocumented. Replace with the stable \`DataFrame.attrs\` API (available since pandas 1.0, preserved through copy/concat in pandas 3.0+).

\`SECONDS_IN_HOUR\` was duplicated across \`io.py\`, \`dip.py\`, \`viability.py\`, and \`plots.py\`. Consolidate to a single definition in \`dip.py\` and import where needed.