### PR TITLE
fix(curve_fit): rename ctrl_resp_data/expt_resp_data to ctrl_data/expt_data in fit_params_from_base

### DIFF
--- a/thunor/curve_fit.py
+++ b/thunor/curve_fit.py
@@ -1501,8 +1501,8 @@ def fit_params(
 
 def fit_params_from_base(
     base_params,
-    ctrl_resp_data=None,
-    expt_resp_data=None,
+    ctrl_data=None,
+    expt_data=None,
     ctrl_dose_fn=lambda doses: np.min(doses) / CTRL_DOSE_DIVISOR,
     custom_ic_concentrations=frozenset(),
     custom_ec_concentrations=frozenset(),
@@ -1533,7 +1533,7 @@ def fit_params_from_base(
 
     if include_response_values:
         df_params = _attach_response_values(
-            df_params, ctrl_resp_data, expt_resp_data, ctrl_dose_fn
+            df_params, ctrl_data, expt_data, ctrl_dose_fn
         )
 
     return df_params


### PR DESCRIPTION
Parameters were named differently from the rest of the fitting pipeline, working only by accident via positional passing. Rename to match `fit_params_minimal` and `fit_params`.