### PR TITLE
fix(io): replace assert with ValueError in _stack_doses()

### DIFF
--- a/thunor/io.py
+++ b/thunor/io.py
@@ -978,7 +978,11 @@ def _stack_doses(df_doses, inplace=True):
     drug_cols = df_doses.filter(regex='^drug[0-9]+$', axis=1)
     dose_cols = df_doses.filter(regex='^dose[0-9]+$', axis=1)
     n_drugs = len(drug_cols.columns)
-    assert n_drugs == len(dose_cols.columns)
+    if n_drugs != len(dose_cols.columns):
+        raise ValueError(
+            f'Mismatched drug/dose columns: found {n_drugs} drug column(s) '
+            f'but {len(dose_cols.columns)} dose column(s)'
+        )
 
     if n_drugs > 1:
         df_doses['drug'] = df_doses.filter(regex='^drug[0-9]+$', axis=1).apply(

--- a/thunor/tests/test_io.py
+++ b/thunor/tests/test_io.py
@@ -208,6 +208,14 @@ class TestCSVTwoDrugs(unittest.TestCase):
         assert len(csv.doses.index.get_level_values('dose')[0]) == 1
 
 
+def test_stack_doses_mismatched_columns_raises():
+    df = pd.DataFrame(
+        {'drug1': ['drugA'], 'dose1': [1e-6], 'dose2': [1e-7], 'cell_line': ['cl1']}
+    )
+    with pytest.raises(ValueError, match='Mismatched drug/dose columns'):
+        thunor.io._stack_doses(df)
+
+
 def test_read_incucyte():
     ref = importlib.resources.files('thunor') / 'testdata/test_incucyte_minimal.txt'
     with importlib.resources.as_file(ref) as filename:


### PR DESCRIPTION
Assertions are stripped under `python -O`. Replace with an explicit `ValueError` so mismatched drug/dose columns always produce a clear error message.