### PR TITLE
docs(curve_fit): note None return for stimulatory responses in auc() and aa()

### DIFF
--- a/thunor/curve_fit.py
+++ b/thunor/curve_fit.py
@@ -321,8 +321,9 @@ class HillCurveLL4(HillCurve):
 
         Returns
         -------
-        float
-            Area under the curve (AUC) value
+        float or None
+            Area under the curve (AUC) value, or ``None`` for stimulatory
+            responses (Emax > E0) which are not yet supported.
         """
         emax = self.emax
         if not isinstance(emax, float):
@@ -355,8 +356,9 @@ class HillCurveLL4(HillCurve):
 
         Returns
         -------
-        float
-            Activity area value
+        float or None
+            Activity area value, or ``None`` for stimulatory responses
+            (Emax > E0) which are not yet supported.
         """
         emax = self.emax
         if not isinstance(emax, float):


### PR DESCRIPTION
Both methods silently return `None` when Emax > E0 (stimulatory/ascending curves). Document this in the return type so callers don't silently lose data.