### PR TITLE
docs: expand doses_unstacked() docstring; document DrugCombosWarning intent

### DIFF
--- a/thunor/curve_fit.py
+++ b/thunor/curve_fit.py
@@ -28,7 +28,15 @@ class AAFitWarning(ValueWarning):
 
 
 class DrugCombosWarning(UserWarning):
-    """Warning issued when drug combination wells are skipped during fitting"""
+    """
+    Warning issued when drug combination wells are skipped during fitting
+
+    :func:`fit_params_minimal` currently fits single-drug dose-response curves
+    only.  Combination wells (where the ``drug`` tuple has length > 1) are
+    filtered out and this warning is issued.  Future versions will support
+    combination fitting via a dedicated code path; the skip-and-warn behaviour
+    is intentional and will not change when that support lands.
+    """
 
     pass
 

--- a/thunor/io.py
+++ b/thunor/io.py
@@ -372,7 +372,21 @@ class HtsPandas(object):
         )
 
     def doses_unstacked(self):
-        """Split multiple drugs/doses into separate columns"""
+        """
+        Return the doses DataFrame with drug/dose tuples split into numbered columns
+
+        Converts the internal stacked representation (``drug``, ``dose`` tuple
+        index levels) into the flat ``drug1``, ``dose1``, ``drug2``, ``dose2``,
+        … column layout used in HDF5 files and required by external tools such
+        as the synergy package for combination-dose matrices.
+
+        Returns
+        -------
+        pd.DataFrame
+            Doses DataFrame indexed by ``(drug1, cell_line, dose1)`` for
+            single-drug datasets, or by ``(drug1, drug2, cell_line, dose1,
+            dose2)`` for combination datasets.
+        """
         # If already unstacked, just return
         if 'drug1' in self.doses.index.names:
             return self.doses


### PR DESCRIPTION
Formally documents `doses_unstacked()` as stable public API needed by the synergy roadmap. Clarifies that `DrugCombosWarning` skip-and-warn behaviour is intentional and will persist when combination fitting is added.