### PR TITLE
docs(changelog): redirect to GitHub releases for changes since v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Thunor Changelog
 ================
 
+Changes since v0.1.15 are documented in
+[GitHub Releases](https://github.com/alubbock/thunor/releases).
+Historical entries below are preserved for reference.
+
+---
+
 ## v0.1.15 2019-03-28
 
 ### Bugfixes


### PR DESCRIPTION
The changelog has not been updated since v0.1.15 (2019); GitHub releases are the active record. Adds a notice at the top pointing there and preserves the historical entries below.