### PR TITLE
feat: declare __all__ in all public modules; add missing docstrings

### DIFF
--- a/thunor/curve_fit.py
+++ b/thunor/curve_fit.py
@@ -5,6 +5,24 @@ from abc import abstractmethod
 import pandas as pd
 import warnings
 
+__all__ = [
+    'ValueWarning',
+    'AUCFitWarning',
+    'AAFitWarning',
+    'DrugCombosWarning',
+    'HillCurve',
+    'HillCurveNull',
+    'HillCurveLL4',
+    'HillCurveLL3u',
+    'HillCurveLL2',
+    'fit_drc',
+    'fit_params_minimal',
+    'fit_params_from_base',
+    'fit_params',
+    'is_param_truncated',
+    'aa_obs',
+]
+
 PARAM_EQUAL_ATOL = 1e-16
 PARAM_EQUAL_RTOL = 1e-12
 # Curve fitting E0 tolerance parameters
@@ -16,15 +34,15 @@ CTRL_DOSE_DIVISOR = 10.0
 
 
 class ValueWarning(UserWarning):
-    pass
+    """Base warning for computed values that may be unreliable"""
 
 
 class AUCFitWarning(ValueWarning):
-    pass
+    """Warning issued when an AUC value may be unreliable"""
 
 
 class AAFitWarning(ValueWarning):
-    pass
+    """Warning issued when an activity area value may be unreliable"""
 
 
 class DrugCombosWarning(UserWarning):
@@ -91,6 +109,8 @@ class HillCurve(object):
 
 
 class HillCurveNull(HillCurve):
+    """Flat (no-effect) curve returned when the null hypothesis cannot be rejected"""
+
     @classmethod
     def fit_fn(cls, x, ymean):
         return ymean
@@ -136,6 +156,8 @@ class HillCurveNull(HillCurve):
 
 
 class HillCurveLL4(HillCurve):
+    """Four-parameter log-logistic Hill curve (E0, Emax, EC50, hill slope)"""
+
     max_fit_evals = 10000
 
     def __init__(self, popt):
@@ -526,6 +548,8 @@ class HillCurveLL3u(HillCurveLL4):
 
 
 class HillCurveLL2(HillCurveLL3u):
+    """Two-parameter log-logistic Hill curve; E0 fixed at 1, Emax fixed at 0"""
+
     fit_bounds = ((0.0, -np.inf), (np.inf, np.inf))
     # LL2 has no bounds at all in linear space; log-EC50 space is also unbounded
     fit_bounds_log = (-np.inf, np.inf)

--- a/thunor/dip.py
+++ b/thunor/dip.py
@@ -5,6 +5,15 @@ import pandas as pd
 SECONDS_IN_HOUR = 3600.0
 DIP_ASSAYS = ('Cell count', 'lum:Lum')
 
+__all__ = [
+    'SECONDS_IN_HOUR',
+    'dip_rates',
+    'expt_dip_rates',
+    'ctrl_dip_rates',
+    'adjusted_r_squared',
+    'tyson1',
+]
+
 
 def _choose_dip_assay(assay_names):
     for assay in DIP_ASSAYS:

--- a/thunor/helpers.py
+++ b/thunor/helpers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
+
+__all__ = ['format_dose', 'plotly_to_dataframe']
 from collections.abc import Iterable
 from html.parser import HTMLParser
 import pandas as pd

--- a/thunor/io.py
+++ b/thunor/io.py
@@ -23,9 +23,23 @@ ANNOTATION_MSG = (
     + 'drug concentrations) must either all be present or all be absent.'
 )
 
+__all__ = [
+    'WELL_ID_SEP',
+    'STANDARD_PLATE_SIZES',
+    'PlateFileParseException',
+    'PlateMap',
+    'PlateData',
+    'HtsPandas',
+    'read_vanderbilt_hts',
+    'write_vanderbilt_hts',
+    'read_hdf',
+    'write_hdf',
+    'read_incucyte',
+]
+
 
 class PlateFileParseException(Exception):
-    pass
+    """Raised when a plate data file cannot be parsed"""
 
 
 class PlateMap(object):
@@ -1135,6 +1149,23 @@ def _read_hdf_unstacked(filename_or_buffer):
 
 
 def read_incucyte(filename_or_buffer, plate_width=24, plate_height=16):
+    """
+    Read an Incucyte Zoom exported file
+
+    Parameters
+    ----------
+    filename_or_buffer: str or file-like object
+        Path to an Incucyte Zoom TSV export file, or a file-like object
+    plate_width: int
+        Width of the microtiter plate in wells (default: 24, for 384-well plate)
+    plate_height: int
+        Height of the microtiter plate in wells (default: 16, for 384-well plate)
+
+    Returns
+    -------
+    HtsPandas
+        HTS Dataset containing the data read from the file
+    """
     LABEL_STR = 'Label: '
     CELL_TYPE_STR = 'Cell Type: '
     TSV_START_STR = 'Date Time\tElapsed\t'

--- a/thunor/plots.py
+++ b/thunor/plots.py
@@ -13,8 +13,21 @@ import pandas as pd
 from collections.abc import Iterable
 
 
+__all__ = [
+    'CannotPlotError',
+    'plot_drc',
+    'plot_drug_combination_heatmap',
+    'plot_drc_params',
+    'plot_time_course',
+    'plot_ctrl_dip_by_plate',
+    'plot_ctrl_cell_counts_by_plate',
+    'plot_plate_map',
+    'plot_two_dataset_param_scatter',
+]
+
+
 class CannotPlotError(ValueError):
-    pass
+    """Raised when a plot cannot be generated from the supplied data"""
 
 
 def _activity_area_units(**kwargs):

--- a/thunor/viability.py
+++ b/thunor/viability.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+__all__ = ['viability']
+
 
 def viability(df_data, *, time_hrs=72, assay_name=None, include_controls=True):
     """


### PR DESCRIPTION
Explicitly declares the stable 1.0 public API surface in every module.

**`__all__` added to:** `io`, `dip`, `curve_fit`, `viability`, `plots`, `helpers`

**Docstrings added:**
- `read_incucyte` — only public function with no docstring
- `PlateFileParseException`, `CannotPlotError`
- `ValueWarning`, `AUCFitWarning`, `AAFitWarning`
- `HillCurveNull`, `HillCurveLL4`, `HillCurveLL2`