### PR TITLE
ci: switch publish workflow to uv build

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,15 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip build
+    - uses: astral-sh/setup-uv@v7
     - name: Build package
-      run: |
-        python -m build --sdist --wheel .
+      run: uv build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Replaces `setup-python` + `pip install build` + `python -m build` with `setup-uv` + `uv build` for consistency with the test workflow.