### PR TITLE
fix(plots): handle float seconds in _secs_to_str

### DIFF
--- a/thunor/plots.py
+++ b/thunor/plots.py
@@ -85,7 +85,7 @@ def _secs_to_str(seconds):
     str
         Formatted string like "Time: 2:04:00"
     """
-    m, s = divmod(seconds, 60)
+    m, s = divmod(int(seconds), 60)
     h, m = divmod(m, 60)
     return f'Time: {h:d}:{m:02d}:{s:02d}'
 

--- a/thunor/tests/test_plots.py
+++ b/thunor/tests/test_plots.py
@@ -9,6 +9,7 @@ import thunor.io
 import thunor.viability
 from thunor.helpers import plotly_to_dataframe
 from thunor.plots import (
+    _secs_to_str,
     plot_ctrl_dip_by_plate,
     plot_drc,
     plot_drc_params,
@@ -139,3 +140,7 @@ class TestWithDataset(unittest.TestCase):
         assert isinstance(df, pd.DataFrame)
         assert list(df.columns) == ['t 0', 't 1']
         assert list(df.index) == [0, 1]
+
+    def test_secs_to_str_float_input(self):
+        # total_seconds() on a pd.Timedelta returns a float
+        assert _secs_to_str(3723.7) == 'Time: 1:02:03'


### PR DESCRIPTION
The %-format to f-string refactor in #116 changed \`'%d' % h\` (silently truncates floats) to \`f'{h:d}'\` (raises ValueError on non-int floats). \`seconds\` here is always a float, from \`pd.Timedelta.total_seconds()\`, so this broke \`plot_drc()\` on the viability path whenever a single curve is rendered.

Casts \`seconds\` to \`int\` up front to restore the old truncation behaviour.