### PR TITLE
refactor(io): clarify blank-drug dose-check precedence

### DIFF
--- a/thunor/io.py
+++ b/thunor/io.py
@@ -714,7 +714,7 @@ def read_vanderbilt_hts(
 
         null_drug_names = df[f'drug{drug_no}'].isnull()
         null_dose_positions = df[f'drug{drug_no}.conc'].loc[null_drug_names]
-        if (~null_dose_positions.isnull() & null_dose_positions != 0.0).any():
+        if ((~null_dose_positions.isnull()) & (null_dose_positions != 0.0)).any():
             raise PlateFileParseException(
                 f'Check that blank drug{drug_no} entries have blank or zero '
                 'concentration also'

--- a/thunor/tests/test_io.py
+++ b/thunor/tests/test_io.py
@@ -208,6 +208,17 @@ class TestCSVTwoDrugs(unittest.TestCase):
         assert len(csv.doses.index.get_level_values('drug')[0]) == 1
         assert len(csv.doses.index.get_level_values('dose')[0]) == 1
 
+    def test_csv_two_drugs_drug2_blank_conc_specified_among_valid_rows(self):
+        # A valid blank-drug2 control well (zero conc) alongside a row with
+        # a blank drug2 name but a genuine nonzero dose - the latter must
+        # still be caught even when mixed with valid rows
+        with pytest.raises(thunor.io.PlateFileParseException):
+            _check_csv(
+                CSV_HEADER + ',drug2,drug2.units,drug2.conc'
+                '\ncl1,0.00013,drug1,plate1,12,1234,A1,M,,M,0'
+                '\ncl1,0.00013,drug1,plate1,12,1235,A2,M,,M,0.00010'
+            )
+
 
 def test_stack_doses_mismatched_columns_raises():
     df = pd.DataFrame(


### PR DESCRIPTION
\`~a.isnull() & a != 0\` relies on Python evaluating \`&\` before \`!=\`, so it actually computes \`(~a.isnull() & a) != 0\`. This happens to be equivalent for float64 data (the bitwise-and implicitly coerces \`a\` to bool, and NaN positions are already masked out by \`~isnull()\`), but it depends on that coincidence and would silently misbehave against nullable Float64 columns.

Adds explicit parentheses - no behaviour change, confirmed by running the new test against both the old and new expression. Also adds a test covering multiple rows with mixed valid/invalid blank-drug entries, which the existing single-row tests didn't exercise.